### PR TITLE
Fix for "Property 'rootStore' does not exist" on Model

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -92,6 +92,11 @@ export type IFluidModel<T> = T &
  */
 export class Model implements IModel {
   /**
+   * Reference to the root store.
+   */
+  rootStore: any
+
+  /**
    * If attributes are specified, `set` is called along with the model options.
    */
   constructor(attributes?: IObjectHash, options?: IModelOptions) {


### PR DESCRIPTION
Referencing `rootStore` within the Model causes TypeScript to fail with `Property 'rootStore' does not exist on type 'X'.`

```
class X extends Model {
 parse(attr){
  this.rootStore;
 }
}
```

Fix adds "rootStore" to Model class.